### PR TITLE
Update the version of node-rdkafka

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "node-rdkafka": "^2.3.3",
+    "node-rdkafka": "^2.7.1",
     "node-zookeeper-client-async": "^1.0.0"
   }
 }


### PR DESCRIPTION
The version of node-rdkafka need to be updated in the package.json file,
as otherwise the version is not porperly installed when using
san-exporter as dependency.