### PR TITLE
Throw exact error provided by librdkafka

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,7 +62,7 @@ exports.Exporter = class {
       this.producer.on("event.error", reject);
       this.producer.on("delivery-report", function(err, report) {
         if(err) {
-          throw "message.max.bytes exceed";
+          throw err;
         }
       });
     });


### PR DESCRIPTION
We can throw the exact error provided by librdkafka. For example the error for missing topic looks like so:

```
{ Error: Broker: Unknown topic or partition
  origin: 'broker',
  message: 'unknown topic or partition',
  code: -1,
  errno: -1,
  stack: 'Error: Broker: Unknown topic or partition' }
```