### PR TITLE
Add metrics

### DIFF
--- a/metrics.js
+++ b/metrics.js
@@ -1,0 +1,40 @@
+const {Counter, Gauge, Summary} = require('prom-client')
+
+module.exports.downloadedTransactionsCounter = new Counter({
+    name: 'downloaded_transactions_count',
+    help: 'Number of transactions downloaded'
+});
+
+module.exports.downloadedBlocksCounter = new Counter({
+    name: 'downloaded_blocks_count',
+    help: 'Number of blocks downloaded'
+});
+
+module.exports.requestsCounter = new Counter({
+    name: 'requests_made_count',
+    help: 'Number of requests made to the node',
+    labelNames: ['connection']
+});
+
+module.exports.requestsResponseTime = new Summary({
+    name: 'requests_response_time',
+    help: 'The response time of the requests to the node',
+    labelNames: ['connection']
+});
+
+module.exports.lastExportedBlock = new Gauge({
+    name: 'last_exported_block',
+    help: 'The last block that was saved by the exporter'
+});
+
+module.exports.currentBlock = new Gauge({
+    name: 'current_block',
+    help: 'The latest blocks on the blockchain'
+});
+
+module.exports.startCollection = function () {
+    console.info(`Starting the collection of metrics, the metrics are available on /metrics`);
+    require('prom-client').collectDefaultMetrics();
+};
+
+module.exports.register = require('prom-client').register


### PR DESCRIPTION
The aim is to unify the metrics that are published from exporters. 