### PR TITLE
Lock node-rdkafka to 2.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "node-rdkafka": "^2.7.1",
+    "node-rdkafka": "~2.8.1",
     "node-zookeeper-client-async": "^1.0.0",
     "node-json-logger": "0.0.10"
   }


### PR DESCRIPTION
node-rdkafka 2.9 fails with:
```
../src/binding.cc: In function 'void Init(v8::Local<v8::Object>, v8::Local<v8::Value>, void*)':
../src/binding.cc:81:28: error: 'GetCurrentEnvironment' is not a member of 'node'
   node::Environment* env = node::GetCurrentEnvironment(context);
                            ^~~~
make: *** [node-librdkafka.target.mk:120: Release/obj.target/node-librdkafka/src/binding.o] Error 1
```