### PR TITLE
Support transactions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:9.11.1-alpine AS builder
+FROM node:15.12.0-alpine AS builder
 
 RUN apk --no-cache add \
       bash \
@@ -21,7 +21,7 @@ COPY package-lock.json /app/package-lock.json
 
 RUN npm install --production
 
-FROM node:9.11.1-alpine
+FROM node:15.12.0-alpine
 
 RUN apk --no-cache add \
   libsasl openssl lz4-libs

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,7 @@ RUN apk --no-cache add \
       cyrus-sasl-dev \
       openssl-dev \
       make \
-      python \
-      git
+      python
 
 RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools bash
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,8 @@ RUN apk --no-cache add \
       cyrus-sasl-dev \
       openssl-dev \
       make \
-      python
+      python \
+      git
 
 RUN apk add --no-cache --virtual .build-deps gcc zlib-dev libc-dev bsd-compat-headers py-setuptools bash
 

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,0 +1,3 @@
+ #! /bin/sh
+
+docker-compose -f ./docker-compose.yml up --build

--- a/bin/run.sh
+++ b/bin/run.sh
@@ -1,3 +1,0 @@
- #! /bin/sh
-
-docker-compose -f ./docker-compose.yml up --build

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,3 @@
+ #! /bin/sh
+
+docker-compose -f ./docker-compose.yml up --build && docker-compose rm -f

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,11 @@
-version: '2'
+version: "3.4"
 services:
   zookeeper:
     image: wurstmeister/zookeeper
     ports:
       - "2181:2181"
+    logging:
+      driver: none
   kafka:
     image: wurstmeister/kafka
     ports:
@@ -13,8 +15,23 @@ services:
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
+    logging:
+      driver: none
   exporter:
-    build: .
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        NODE_ENV: development
+    depends_on:
+      - zookeeper
+      - kafka
     environment:
       KAFKA_URL: kafka:9092
       ZOOKEEPER_URL: zookeeper:2181
+      KAFKA_TOPIC: san_exporter_test
+    ports:
+      # port for checking health.
+      - "127.0.0.1:3000:3000"
+    entrypoint: "/bin/sh"
+    command: ["-c", "docker/wait_for_services.sh && node examples/send_dates.js && node examples/send_dates_transaction.js"]

--- a/docker/wait_for_services.sh
+++ b/docker/wait_for_services.sh
@@ -1,0 +1,10 @@
+#! /bin/sh
+
+# Wait for Kafka
+until nc -z -v -w30 kafka 9092
+do
+  echo 'Waiting for Kafka...'
+  sleep 1
+done
+
+echo "Kafka is up and running"

--- a/examples/send_dates.js
+++ b/examples/send_dates.js
@@ -3,19 +3,16 @@ const { Exporter } = require('../index')
 const exporter = new Exporter(pkg.name)
 
 async function pushData(num_iteration) {
-  const timestamp = Math.floor(new Date() / 1000)
-
   let lastPosition = await exporter.getLastPosition()
   console.log(`Last position: ${JSON.stringify(lastPosition)}`)
-  let key = 1
-  if(lastPosition) {
-    key = lastPosition.key + 1
-  }
+  const key = lastPosition ? lastPosition.key + 1 : 1
 
+  const now = new Date()
+  const timestamp = Math.floor(now.getTime() / 1000)
   console.log("Sending data, iteration", num_iteration);
   await exporter.sendDataWithKey({
     timestamp: timestamp,
-    iso_date: new Date().toISOString(),
+    iso_date: now.toISOString(),
     key: key
   }, "key")
 

--- a/examples/send_dates.js
+++ b/examples/send_dates.js
@@ -35,7 +35,7 @@ async function work() {
     await pushData(i)
   }
 
-  await exporter.disconnect();
+  exporter.disconnect();
 }
 
 work()

--- a/examples/send_dates.js
+++ b/examples/send_dates.js
@@ -28,7 +28,8 @@ async function pushData(num_iteration) {
 }
 
 async function work() {
-  await exporter.connect()
+  await exporter.connect();
+  console.log("Connected to Kafka");
 
   for (i = 0; i <= 10; i++) {
     await pushData(i)

--- a/examples/send_dates_transaction.js
+++ b/examples/send_dates_transaction.js
@@ -3,19 +3,16 @@ const { Exporter } = require('../index')
 const exporter = new Exporter(pkg.name, true)
 
 async function pushData() {
-  const timestamp = Math.floor(new Date() / 1000)
-
   let lastPosition = await exporter.getLastPosition()
   console.log(`Last position: ${JSON.stringify(lastPosition)}`)
-  let key = 1
-  if(lastPosition) {
-    key = lastPosition.key + 1
-  }
+  const key = lastPosition ? lastPosition.key + 1 : 1
 
+  const now = new Date()
+  const timestamp = Math.floor(now.getTime() / 1000)
   console.log("Sending data with transaction...")
   await exporter.sendDataWithKey({
     timestamp: timestamp,
-    iso_date: new Date().toISOString(),
+    iso_date: now.toISOString(),
     key: key
   }, "key")
 
@@ -25,7 +22,6 @@ async function pushData() {
 
   let newPosition = await exporter.getLastPosition()
   console.log(`New position: ${JSON.stringify(newPosition)}`)
-
 }
 
 async function work() {

--- a/examples/send_dates_transaction.js
+++ b/examples/send_dates_transaction.js
@@ -1,8 +1,8 @@
 const pkg = require('../package.json');
 const { Exporter } = require('../index')
-const exporter = new Exporter(pkg.name)
+const exporter = new Exporter(pkg.name, true)
 
-async function pushData(num_iteration) {
+async function pushData() {
   const timestamp = Math.floor(new Date() / 1000)
 
   let lastPosition = await exporter.getLastPosition()
@@ -12,7 +12,7 @@ async function pushData(num_iteration) {
     key = lastPosition.key + 1
   }
 
-  console.log("Sending data, iteration", num_iteration);
+  console.log("Sending data with transaction...")
   await exporter.sendDataWithKey({
     timestamp: timestamp,
     iso_date: new Date().toISOString(),
@@ -25,15 +25,20 @@ async function pushData(num_iteration) {
 
   let newPosition = await exporter.getLastPosition()
   console.log(`New position: ${JSON.stringify(newPosition)}`)
+
 }
 
 async function work() {
-  await exporter.connect()
+  console.log("Start sending data with transactions.");
+  await exporter.connect();
+  exporter.initTransactions();
+  exporter.beginTransaction();
 
   for (i = 0; i <= 10; i++) {
-    await pushData(i)
+    await pushData()
   }
 
+  exporter.commitTransaction();
   await exporter.disconnect();
 }
 

--- a/examples/send_dates_transaction.js
+++ b/examples/send_dates_transaction.js
@@ -39,7 +39,7 @@ async function work() {
   }
 
   exporter.commitTransaction();
-  await exporter.disconnect();
+  exporter.disconnect();
 }
 
 work()

--- a/index.js
+++ b/index.js
@@ -190,6 +190,7 @@ exports.Exporter = class {
   }
 
   /**
+   * Subscribe to delivery reports.
    * @param {Function} Callback to be invoked on message delivery.
    */
   async subscribeDeliveryReports(callback) {

--- a/index.js
+++ b/index.js
@@ -64,8 +64,7 @@ exports.Exporter = class {
     await zookeeperClient.connectAsync();
 
     logger.info(`Connecting to kafka host ${KAFKA_URL}`);
-    this.producer.connect();
-    return new Promise((resolve, reject) => {
+    var promise_result = new Promise((resolve, reject) => {
       this.producer.on("ready", resolve);
       this.producer.on("event.error", reject);
       this.producer.on("delivery-report", function(err, report) {
@@ -74,6 +73,8 @@ exports.Exporter = class {
         }
       });
     });
+    this.producer.connect();
+    return promise_result;
   }
   /**
    * Disconnect from Zookeeper and Kafka.

--- a/index.js
+++ b/index.js
@@ -82,8 +82,13 @@ exports.Exporter = class {
   disconnect(callback) {
     logger.info(`Disconnecting from zookeeper host ${ZOOKEEPER_URL}`);
     zookeeperClient.closeAsync().then( () => {
-      logger.info(`Disconnecting from kafka host ${KAFKA_URL}`);
-      this.producer.disconnect(callback);
+      if (this.producer.isConnected()) {
+        logger.info(`Disconnecting from kafka host ${KAFKA_URL}`);
+        this.producer.disconnect(callback);
+      }
+      else {
+        logger.info(`Producer is NOT connected to kafka host ${KAFKA_URL}`);
+      }
     })
   }
 

--- a/index.js
+++ b/index.js
@@ -59,14 +59,8 @@ exports.Exporter = class {
 
     logger.info(`Connecting to kafka host ${KAFKA_URL}`);
     this.producer.connect();
-
-    function initTransactionsAndResolve(resolve, producer) {
-      producer.initTransactions(TRANSACTIONS_TIMEOUT_MS);
-      resolve
-    };
-
     return new Promise((resolve, reject) => {
-      this.producer.on("ready", initTransactionsAndResolve(resolve, this. producer));
+      this.producer.on("ready", resolve);
       this.producer.on("event.error", reject);
       this.producer.on("delivery-report", function(err, report) {
         if(err) {
@@ -159,6 +153,9 @@ exports.Exporter = class {
     );
   }
 
+  async initTransactions() {
+    this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS);
+  }
   async beginTransaction() {
     this.producer.beginTransaction();
   }

--- a/index.js
+++ b/index.js
@@ -75,13 +75,16 @@ exports.Exporter = class {
       });
     });
   }
-
-  async disconnect() {
+  /**
+   * Disconnect from Zookeeper and Kafka.
+   * This method is completed once the callback is invoked.
+   */
+  disconnect(callback) {
     logger.info(`Disconnecting from zookeeper host ${ZOOKEEPER_URL}`);
-    await zookeeperClient.closeAsync();
-
-    logger.info(`Disconnecting from kafka host ${KAFKA_URL}`);
-    this.producer.disconnect();
+    zookeeperClient.closeAsync().then( () => {
+      logger.info(`Disconnecting from kafka host ${KAFKA_URL}`);
+      this.producer.disconnect(callback);
+    })
   }
 
   async getLastPosition() {

--- a/index.js
+++ b/index.js
@@ -185,16 +185,16 @@ exports.Exporter = class {
   }
 
   initTransactions() {
-    this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS);
+    return this.producer.initTransactions(TRANSACTIONS_TIMEOUT_MS);
   }
   beginTransaction() {
-    this.producer.beginTransaction();
+    return this.producer.beginTransaction();
   }
   commitTransaction() {
-    this.producer.commitTransaction(TRANSACTIONS_TIMEOUT_MS);
+    return this.producer.commitTransaction(TRANSACTIONS_TIMEOUT_MS);
   }
   abortTransaction() {
-    this.producer.abortTransaction(TRANSACTIONS_TIMEOUT_MS);
+    return this.producer.abortTransaction(TRANSACTIONS_TIMEOUT_MS);
   }
 
 };

--- a/index.js
+++ b/index.js
@@ -1,4 +1,4 @@
-const Kafka = require("node-rdkafka");
+const Kafka = require("@santiment-network/node-rdkafka");
 const zk = require("node-zookeeper-client-async");
 const { logger } = require('./logger')
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,368 @@
 {
   "name": "@santiment-network/san-exporter",
   "version": "0.0.7",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
-  "dependencies": {
-    "babylon": {
-      "version": "7.0.0-beta.19",
-      "resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.19.tgz",
-      "integrity": "sha512-Vg0C9s/REX6/WIXN37UKpv5ZhRi6A4pjHlpkE34+8/a6c2W1Q692n3hmc+SZG5lKRnaExLUbxtJ1SVT+KaCQ/A==",
+  "packages": {
+    "": {
+      "name": "@santiment-network/san-exporter",
+      "version": "0.0.7",
+      "license": "MIT",
+      "dependencies": {
+        "@santiment-network/node-rdkafka": "^2.9.2",
+        "node-json-logger": "^0.0.11",
+        "node-zookeeper-client-async": "^1.0.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+      "optional": true,
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@santiment-network/node-rdkafka": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.2.tgz",
+      "integrity": "sha512-xpogea/Vr7qvsud44C5dMxRVAdKSNvs1yWZkaB1MAzueLBbbmp8rmbXOZ40agRp84X8uHjkP6QwgQshtxbdPMQ==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "optional": true,
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "optional": true
+    },
+    "node_modules/catharsis": {
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
+      "optional": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "optional": true
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
+      "optional": true
+    },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
+      "optional": true,
+      "dependencies": {
+        "xmlcreate": "^2.0.3"
+      }
+    },
+    "node_modules/jsdoc": {
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
+      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
+      "optional": true,
+      "dependencies": {
+        "@babel/parser": "^7.9.4",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.8.11",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.1",
+        "klaw": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "markdown-it-anchor": "^5.2.7",
+        "marked": "^0.8.2",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "taffydb": "2.6.2",
+        "underscore": "~1.10.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=8.15.0"
+      }
+    },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "optional": true,
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "optional": true,
+      "dependencies": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "optional": true
+    },
+    "node_modules/markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "optional": true,
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.js"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "optional": true,
+      "peerDependencies": {
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "optional": true,
+      "bin": {
+        "marked": "bin/marked"
+      },
+      "engines": {
+        "node": ">= 8.16.2"
+      }
+    },
+    "node_modules/mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
+      "optional": true
+    },
+    "node_modules/mkdirp": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "optional": true,
+      "bin": {
+        "mkdirp": "bin/cmd.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/moment": {
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/moment-timezone": {
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
+      "dependencies": {
+        "moment": ">= 2.9.0"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
+    },
+    "node_modules/node-json-logger": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/node-json-logger/-/node-json-logger-0.0.11.tgz",
+      "integrity": "sha512-9HMqg1umRvCzJiiJ308qvWp6LBniPnZnMqfCG2j4UpBEt/hmWMVGliOOaQOQ2C0swlmFOTZiDqLUxRGVeAVv6Q==",
+      "dependencies": {
+        "moment-timezone": "^0.5.31"
+      }
+    },
+    "node_modules/node-zookeeper-client": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
+      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
+      "dependencies": {
+        "async": "~0.2.7",
+        "underscore": "~1.4.4"
+      },
+      "engines": {
+        "node": ">=0.6.0"
+      }
+    },
+    "node_modules/node-zookeeper-client-async": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client-async/-/node-zookeeper-client-async-1.0.0.tgz",
+      "integrity": "sha512-h2rrxDxK7JMnZkvG90Dodo5Iu0o3ZntqlJLIUJw4shSxDdOoXCMi7Wb6w/sfl1fON9bO4wQptORyFfWnvjKpuw==",
+      "dependencies": {
+        "node-zookeeper-client": "^0.2.2"
+      },
+      "optionalDependencies": {
+        "bluebird": "^3.5.0",
+        "jsdoc": "^3.4.3"
+      }
+    },
+    "node_modules/node-zookeeper-client/node_modules/underscore": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
+      "optional": true,
+      "dependencies": {
+        "lodash": "^4.17.14"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "optional": true
+    },
+    "node_modules/strip-json-comments": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/taffydb": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/taffydb/-/taffydb-2.6.2.tgz",
+      "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
+      "optional": true
+    },
+    "node_modules/uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "optional": true
+    },
+    "node_modules/underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "optional": true
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
+      "optional": true
+    }
+  },
+  "dependencies": {
+    "@babel/parser": {
+      "version": "7.13.13",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
+      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+      "optional": true
+    },
+    "@santiment-network/node-rdkafka": {
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.2.tgz",
+      "integrity": "sha512-xpogea/Vr7qvsud44C5dMxRVAdKSNvs1yWZkaB1MAzueLBbbmp8rmbXOZ40agRp84X8uHjkP6QwgQshtxbdPMQ==",
+      "requires": {
+        "bindings": "^1.3.1",
+        "nan": "^2.14.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "optional": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "async": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+      "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
     },
     "bindings": {
       "version": "1.5.0",
@@ -19,24 +373,30 @@
       }
     },
     "bluebird": {
-      "version": "3.5.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
-      "integrity": "sha512-MKiLiV+I1AA596t9w1sQJ8jkiSr5+ZKi0WKrYGUn6d1Fx+Ij4tIj+m2WMQSGczs5jZVxV339chE8iwk6F64wjA==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "optional": true
     },
     "catharsis": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.9.tgz",
-      "integrity": "sha1-mMyJDKZS3S7w5ws3klMQ/56Q/Is=",
+      "version": "0.8.11",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.8.11.tgz",
+      "integrity": "sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==",
       "optional": true,
       "requires": {
-        "underscore-contrib": "~0.3.0"
+        "lodash": "^4.17.14"
       }
     },
+    "entities": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-2.0.3.tgz",
+      "integrity": "sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==",
+      "optional": true
+    },
     "escape-string-regexp": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
       "optional": true
     },
     "file-uri-to-path": {
@@ -45,95 +405,121 @@
       "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
     },
     "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg=",
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
+      "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "optional": true
     },
     "js2xmlparser": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-3.0.0.tgz",
-      "integrity": "sha1-P7YOqgicVED5MZ9RdgzNB+JJlzM=",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.1.tgz",
+      "integrity": "sha512-KrPTolcw6RocpYjdC7pL7v62e55q7qOMHvLX1UCLc5AAS8qeJ6nukarEJAF2KL2PZxlbGueEbINqZR2bDe/gUw==",
       "optional": true,
       "requires": {
-        "xmlcreate": "^1.0.1"
+        "xmlcreate": "^2.0.3"
       }
     },
     "jsdoc": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.5.5.tgz",
-      "integrity": "sha512-6PxB65TAU4WO0Wzyr/4/YhlGovXl0EVYfpKbpSroSj0qBxT4/xod/l40Opkm38dRHRdQgdeY836M0uVnJQG7kg==",
+      "version": "3.6.6",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-3.6.6.tgz",
+      "integrity": "sha512-znR99e1BHeyEkSvgDDpX0sTiTu+8aQyDl9DawrkOGZTTW8hv0deIFXx87114zJ7gRaDZKVQD/4tr1ifmJp9xhQ==",
       "optional": true,
       "requires": {
-        "babylon": "7.0.0-beta.19",
-        "bluebird": "~3.5.0",
-        "catharsis": "~0.8.9",
-        "escape-string-regexp": "~1.0.5",
-        "js2xmlparser": "~3.0.0",
-        "klaw": "~2.0.0",
-        "marked": "~0.3.6",
-        "mkdirp": "~0.5.1",
-        "requizzle": "~0.2.1",
-        "strip-json-comments": "~2.0.1",
+        "@babel/parser": "^7.9.4",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.8.11",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.1",
+        "klaw": "^3.0.0",
+        "markdown-it": "^10.0.0",
+        "markdown-it-anchor": "^5.2.7",
+        "marked": "^0.8.2",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
         "taffydb": "2.6.2",
-        "underscore": "~1.8.3"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
-          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI=",
-          "optional": true
-        }
+        "underscore": "~1.10.2"
       }
     },
     "klaw": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-2.0.0.tgz",
-      "integrity": "sha1-WcEo4Nxc5BAgEVEZTuucv4WGUPY=",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
       "optional": true,
       "requires": {
         "graceful-fs": "^4.1.9"
       }
     },
-    "marked": {
-      "version": "0.3.19",
-      "resolved": "https://registry.npmjs.org/marked/-/marked-0.3.19.tgz",
-      "integrity": "sha512-ea2eGWOqNxPcXv8dyERdSr/6FmzvWwzjMxpfGB/sbMccXoct+xY+YukPD+QTUZwyvK7BZwcr4m21WBOW41pAkg==",
+    "linkify-it": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-2.2.0.tgz",
+      "integrity": "sha512-GnAl/knGn+i1U/wjBz3akz2stz+HrHLsxMwHQGofCDfPvlf+gDKN58UtfmUquTY4/MXeE2x7k19KQmeoZi94Iw==",
+      "optional": true,
+      "requires": {
+        "uc.micro": "^1.0.1"
+      }
+    },
+    "lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
       "optional": true
     },
-    "minimist": {
-      "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+    "markdown-it": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-10.0.0.tgz",
+      "integrity": "sha512-YWOP1j7UbDNz+TumYP1kpwnP0aEa711cJjrAQrzd0UXlbJfc5aAq0F/PZHjiioqDC1NKgvIMX+o+9Bk7yuM2dg==",
+      "optional": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "entities": "~2.0.0",
+        "linkify-it": "^2.0.0",
+        "mdurl": "^1.0.1",
+        "uc.micro": "^1.0.5"
+      }
+    },
+    "markdown-it-anchor": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz",
+      "integrity": "sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==",
+      "optional": true,
+      "requires": {}
+    },
+    "marked": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-0.8.2.tgz",
+      "integrity": "sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==",
+      "optional": true
+    },
+    "mdurl": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
+      "integrity": "sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=",
       "optional": true
     },
     "mkdirp": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "optional": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+      "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
+      "optional": true
     },
     "moment": {
-      "version": "2.27.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.27.0.tgz",
-      "integrity": "sha512-al0MUK7cpIcglMv3YF13qSgdAIqxHTO7brRtaz3DlSULbqfazqkc5kEjNrLDOM7fsjshoFIihnU8snrP7zUvhQ=="
+      "version": "2.29.1",
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "moment-timezone": {
-      "version": "0.5.31",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.31.tgz",
-      "integrity": "sha512-+GgHNg8xRhMXfEbv81iDtrVeTcWt0kWmTEY1XQK14dICTXnWJnT0dxdlPspwqF3keKMVPXwayEsk1DI0AA/jdA==",
+      "version": "0.5.33",
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.33.tgz",
+      "integrity": "sha512-PTc2vcT8K9J5/9rDEPe5czSIKgLoGsH8UNpA4qZTVw0Vd/Uz19geE9abbIOQKaAQFcnQ3v5YEXrbSc5BpshH+w==",
       "requires": {
         "moment": ">= 2.9.0"
       }
     },
     "nan": {
-      "version": "2.14.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-      "integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ=="
     },
     "node-json-logger": {
       "version": "0.0.11",
@@ -143,28 +529,19 @@
         "moment-timezone": "^0.5.31"
       }
     },
-    "node-rdkafka": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/node-rdkafka/-/node-rdkafka-2.9.1.tgz",
-      "integrity": "sha512-C5EVDZlDG+5D8KXiz2zKwEiLWIGW5Z1mkVFRzp13T4mrbXz+ESyjrDSLIj7aoUIi5+T10H9p1wwLZJBh9ivjLg==",
-      "requires": {
-        "bindings": "^1.3.1",
-        "nan": "^2.14.0"
-      }
-    },
     "node-zookeeper-client": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.2.tgz",
-      "integrity": "sha1-CXvaAZme749gLOBotjJgAGnb9oU=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/node-zookeeper-client/-/node-zookeeper-client-0.2.3.tgz",
+      "integrity": "sha512-V4gVHxzQ42iwhkANpPryzfjmqi3Ql3xeO9E/px7W5Yi774WplU3YtqUpnvcL/eJit4UqcfuLOgZLkpf0BPhHmg==",
       "requires": {
         "async": "~0.2.7",
         "underscore": "~1.4.4"
       },
       "dependencies": {
-        "async": {
-          "version": "0.2.10",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
-          "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
+        "underscore": {
+          "version": "1.4.4",
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
+          "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
         }
       }
     },
@@ -179,26 +556,24 @@
       }
     },
     "requizzle": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.1.tgz",
-      "integrity": "sha1-aUPDUwxNmn5G8c3dUcFY/GcM294=",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.3.tgz",
+      "integrity": "sha512-YanoyJjykPxGHii0fZP0uUPEXpvqfBDxWV7s6GKAiiOsiqhX6vHNyW3Qzdmqp/iq/ExbhaGbVrjB4ruEVSM4GQ==",
       "optional": true,
       "requires": {
-        "underscore": "~1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "optional": true
-        }
+        "lodash": "^4.17.14"
       }
     },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "optional": true
+    },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+      "integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
       "optional": true
     },
     "taffydb": {
@@ -207,32 +582,22 @@
       "integrity": "sha1-fLy2S1oUG2ou/CxdLGe04VCyomg=",
       "optional": true
     },
-    "underscore": {
-      "version": "1.4.4",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.4.4.tgz",
-      "integrity": "sha1-YaajIBBiKvoHljvzJSA88SI51gQ="
+    "uc.micro": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-1.0.6.tgz",
+      "integrity": "sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==",
+      "optional": true
     },
-    "underscore-contrib": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/underscore-contrib/-/underscore-contrib-0.3.0.tgz",
-      "integrity": "sha1-ZltmwkeD+PorGMn4y7Dix9SMJsc=",
-      "optional": true,
-      "requires": {
-        "underscore": "1.6.0"
-      },
-      "dependencies": {
-        "underscore": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.6.0.tgz",
-          "integrity": "sha1-izixDKze9jM3uLJOT/htRa6lKag=",
-          "optional": true
-        }
-      }
+    "underscore": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.10.2.tgz",
+      "integrity": "sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==",
+      "optional": true
     },
     "xmlcreate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-1.0.2.tgz",
-      "integrity": "sha1-+mv3YqYKQT+z3Y9LA8WyaSONMI8=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.3.tgz",
+      "integrity": "sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==",
       "optional": true
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,15 +9,15 @@
       "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
-        "@santiment-network/node-rdkafka": "^2.9.2",
+        "@santiment-network/node-rdkafka": "2.10.7",
         "node-json-logger": "^0.0.11",
         "node-zookeeper-client-async": "^1.0.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
       "optional": true,
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@santiment-network/node-rdkafka": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.2.tgz",
-      "integrity": "sha512-xpogea/Vr7qvsud44C5dMxRVAdKSNvs1yWZkaB1MAzueLBbbmp8rmbXOZ40agRp84X8uHjkP6QwgQshtxbdPMQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.7.tgz",
+      "integrity": "sha512-xAv9a8SiuiGE3yt8SR0/ZRCTyQyItjOBDsMm/2iyttN8QnfRVHd9WsdLRDhBCILqqHE9555PocHrVKbnT5rnPA==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.3.1",
@@ -336,15 +336,15 @@
   },
   "dependencies": {
     "@babel/parser": {
-      "version": "7.13.13",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.13.tgz",
-      "integrity": "sha512-OhsyMrqygfk5v8HmWwOzlYjJrtLaFhF34MrfG/Z73DgYCI6ojNUTUp2TYbtnjo8PegeJp12eamsNettCQjKjVw==",
+      "version": "7.13.15",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.13.15.tgz",
+      "integrity": "sha512-b9COtcAlVEQljy/9fbcMHpG+UIW9ReF+gpaxDHTlZd0c6/UU9ng8zdySAW9sRTzpvcdCHn6bUcbuYUgGzLAWVQ==",
       "optional": true
     },
     "@santiment-network/node-rdkafka": {
-      "version": "2.10.2",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.2.tgz",
-      "integrity": "sha512-xpogea/Vr7qvsud44C5dMxRVAdKSNvs1yWZkaB1MAzueLBbbmp8rmbXOZ40agRp84X8uHjkP6QwgQshtxbdPMQ==",
+      "version": "2.10.7",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.7.tgz",
+      "integrity": "sha512-xAv9a8SiuiGE3yt8SR0/ZRCTyQyItjOBDsMm/2iyttN8QnfRVHd9WsdLRDhBCILqqHE9555PocHrVKbnT5rnPA==",
       "requires": {
         "bindings": "^1.3.1",
         "nan": "^2.14.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.7",
       "license": "MIT",
       "dependencies": {
-        "@santiment-network/node-rdkafka": "2.10.7",
+        "@santiment-network/node-rdkafka": "2.10.10",
         "node-json-logger": "^0.0.11",
         "node-zookeeper-client-async": "^1.0.0"
       }
@@ -27,9 +27,9 @@
       }
     },
     "node_modules/@santiment-network/node-rdkafka": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.7.tgz",
-      "integrity": "sha512-xAv9a8SiuiGE3yt8SR0/ZRCTyQyItjOBDsMm/2iyttN8QnfRVHd9WsdLRDhBCILqqHE9555PocHrVKbnT5rnPA==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.10.tgz",
+      "integrity": "sha512-ernMsSGKiE+m5/7R/+rJO+g/74aURLZQS3EOiwSWRiYj5iSCGCtJfS5ne60/MjfVeuGCpsnCnnhuFiKIpV/jDA==",
       "hasInstallScript": true,
       "dependencies": {
         "bindings": "^1.3.1",
@@ -342,9 +342,9 @@
       "optional": true
     },
     "@santiment-network/node-rdkafka": {
-      "version": "2.10.7",
-      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.7.tgz",
-      "integrity": "sha512-xAv9a8SiuiGE3yt8SR0/ZRCTyQyItjOBDsMm/2iyttN8QnfRVHd9WsdLRDhBCILqqHE9555PocHrVKbnT5rnPA==",
+      "version": "2.10.10",
+      "resolved": "https://registry.npmjs.org/@santiment-network/node-rdkafka/-/node-rdkafka-2.10.10.tgz",
+      "integrity": "sha512-ernMsSGKiE+m5/7R/+rJO+g/74aURLZQS3EOiwSWRiYj5iSCGCtJfS5ne60/MjfVeuGCpsnCnnhuFiKIpV/jDA==",
       "requires": {
         "bindings": "^1.3.1",
         "nan": "^2.14.0"

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "@santiment-network/node-rdkafka": "^2.9.2",
+    "@santiment-network/node-rdkafka": "2.10.7",
     "node-json-logger": "^0.0.11",
     "node-zookeeper-client-async": "^1.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "node-rdkafka": "^2.9.1",
+    "node-rdkafka": "santiment/node-rdkafka",
     "node-zookeeper-client-async": "^1.0.0",
     "node-json-logger": "^0.0.11"
   }

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "node-rdkafka": "santiment/node-rdkafka",
-    "node-zookeeper-client-async": "^1.0.0",
-    "node-json-logger": "^0.0.11"
+    "@santiment-network/node-rdkafka": "^2.9.2",
+    "node-json-logger": "^0.0.11",
+    "node-zookeeper-client-async": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "homepage": "https://github.com/santiment/san-exporter",
   "dependencies": {
-    "@santiment-network/node-rdkafka": "2.10.7",
+    "@santiment-network/node-rdkafka": "2.10.10",
     "node-json-logger": "^0.0.11",
     "node-zookeeper-client-async": "^1.0.0"
   }


### PR DESCRIPTION
This PR adds Kafka transaction support to san-exporter. We need this to provide 'exactly once' semantic.

The bigger work related with this PR has been happening in Node-rdkafka. The library is a wrapper over Librdkafka which supports transactions, but that support needs to be brought to JS. I have been trying to do this in this PR:
https://github.com/Blizzard/node-rdkafka/pull/881
If you feel like doing so, please also comment there. My PR is still not accepted so for now we use an NPM from our own NPM repo: `@santiment-network/node-rdkafka`.

Also in this PR I have done some fixes:
* Zookeeper client is now a member instead of global variable. Global variable was causing weird problems in integration tests, when the san-exporter is dropped and created again.
* I have added an example for using transactions and also made the examples runnable as a sort of test.
* Added a helper method to subscribe for message delivery.

P.S. I am tagging more people for this PR, because we have bigger plans for san-exporter. The idea is for it to gradually absorb all other exporters into a single higher quality repository which people outside of Santiment would use. So any feedback is welcome.